### PR TITLE
fixing 1120; write VLL for primary_voltage and secondary_voltage of 3-…

### DIFF
--- a/blazegraph/src/main/java/gov/pnnl/goss/cim2glm/components/DistPowerXfmrWinding.java
+++ b/blazegraph/src/main/java/gov/pnnl/goss/cim2glm/components/DistPowerXfmrWinding.java
@@ -166,8 +166,8 @@ public class DistPowerXfmrWinding extends DistComponent {
 		} else {
 			buf.append ("  connect_type " + sConnect + ";\n");
 		}
-		buf.append ("  primary_voltage " + df3.format (ratedU[0] / Math.sqrt(3.0)) + ";\n");
-		buf.append ("  secondary_voltage " + df3.format (ratedU[1] / Math.sqrt(3.0)) + ";\n");
+		buf.append ("  primary_voltage " + df3.format (ratedU[0]) + ";\n");
+		buf.append ("  secondary_voltage " + df3.format (ratedU[1]) + ";\n");
 		buf.append ("  power_rating " + df3.format (ratedS[0] * 0.001) + ";\n");
 		int idx;
 		double Zbase;


### PR DESCRIPTION
…phase transformers

This was a defect that I noticed back in October, and apparently never merged back into develop.  In GridLAB-D, some people input **line-to-line** voltages for the transformer **primary_voltage** and **secondary_voltage** attributes; this is correct.  Others input line-to-neutral voltages, which produces the correct turns ratio, but the transformer impedances that are too high by a factor of three because of the impact on Zbase.  The difference isn't always obvious to a user, but it would affect benchmarking of accurate results.

I will merge this myself later in the week, unless one of the reviewers objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/powergrid-models/77)
<!-- Reviewable:end -->
