### PR TITLE
add missing s2 phase

### DIFF
--- a/blazegraph/src/main/java/gov/pnnl/goss/cim2glm/components/DistComponent.java
+++ b/blazegraph/src/main/java/gov/pnnl/goss/cim2glm/components/DistComponent.java
@@ -196,9 +196,9 @@ public abstract class DistComponent {
 			return bus + ".3.1";
 		} else if (phs.contains ("C:B")) {
 			return bus + ".3.2";
-		} else if (phs.contains ("s1:s2")) {
+		} else if (phs.contains ("s1:s2") || phs.contains ("s1s2")) {
 			return bus + ".1.2";
-		} else if (phs.contains ("s2:s1")) {
+		} else if (phs.contains ("s2:s1") || phs.contains ("s2s1")) {
 			return bus + ".2.1";
 		} else if (phs.contains ("s1")) {
 			return bus + ".1";


### PR DESCRIPTION
Re-exported OpenDSS model was missing the s2 secondary phases in some instances

Also fixed in https://github.com/GRIDAPPSD/CIMHub/tree/develop

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/powergrid-models/83)
<!-- Reviewable:end -->
