### PR TITLE
making the SoC meaurement mRID persistent

### DIFF
--- a/Meas/InsertMeasurements.py
+++ b/Meas/InsertMeasurements.py
@@ -123,10 +123,14 @@ for ln in lines:
     trmid = toks[7]
     name = 'PowerElectronicsConnection_BatteryUnit_' + toks[3]
     key = name + ':' + bus + ':' + phases
-    id1 = getMeasurementID (key + ':PNV', uuidDict)
-    id2 = getMeasurementID (key + ':VA', uuidDict)
-    InsertMeasurement ('Analog', id1, name, eqid, trmid, 'PNV', phases)
-    InsertMeasurement ('Analog', id2, name, eqid, trmid, 'VA', phases)
+    if phases == 'SoC':
+      id1 = getMeasurementID (key + ':SoC', uuidDict)
+      InsertMeasurement ('Analog', id1, name, eqid, trmid, 'SoC', 'none')
+    else:
+      id1 = getMeasurementID (key + ':PNV', uuidDict)
+      id2 = getMeasurementID (key + ':VA', uuidDict)
+      InsertMeasurement ('Analog', id1, name, eqid, trmid, 'PNV', phases)
+      InsertMeasurement ('Analog', id2, name, eqid, trmid, 'VA', phases)
   if toks[0] == 'PowerTransformer' and toks[1] == 'PowerTransformerEnd':
     what = toks[2]
     bus = toks[5]

--- a/Meas/ieee13nodeckt_measid.json
+++ b/Meas/ieee13nodeckt_measid.json
@@ -183,5 +183,7 @@
   "PowerTransformer_xfm1:xf1:C:VA": "_ac3b5302-cffe-4ba2-82d1-165e8ea793a2",
   "PowerTransformer_xfm1:634:A:VA": "_bdf6271a-832a-40db-b7aa-2c9153a6b59f",
   "PowerTransformer_xfm1:634:B:VA": "_7845cc4d-ea6b-4322-ac62-0ef3815a514e",
-  "PowerTransformer_xfm1:634:C:VA": "_44300afb-c52e-4509-a37f-26a31560c89f"
+  "PowerTransformer_xfm1:634:C:VA": "_44300afb-c52e-4509-a37f-26a31560c89f",
+  "PowerElectronicsConnection_BatteryUnit_house:house:SoC:SoC": "_2656dca3-0d6f-4ded-abd1-de6ef6e2eeb5",
+  "PowerElectronicsConnection_BatteryUnit_school:634:SoC:SoC": "_cb12b959-8b26-4cc6-9169-b8be54fddfde"
 }

--- a/blazegraph/pom.xml
+++ b/blazegraph/pom.xml
@@ -15,7 +15,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>11</release>
+					  <source>1.8</source>
+					  <target>1.8</target>
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                     </compilerArgs>


### PR DESCRIPTION
The SoC implementation was merged into **develop** before persistent mRID. This makes the SoC measurements have persistent mRID, like the other measurements. To test:

1. start blazegraph; any existing database contents will be overwritten during the test
2. from the `Meas` subdirectory, execute `test_mrid.sh`
3. from the `blazegraph` subdirectory, execute `import.sh`
4. in the created `ieee13_dict.json` file, Measurements section, you should find two entries with measurementType `SoC` and phases `none`
5. if you repeat steps **2** and **3**, the mRID values for SoC should stay the same in step **4**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/powergrid-models/85)
<!-- Reviewable:end -->
