### PR TITLE
Feature/1105

### DIFF
--- a/platform/check_pnnl.dss
+++ b/platform/check_pnnl.dss
@@ -1,0 +1,13 @@
+//
+clear
+cd /home/tom/src/Powergrid-Models/platform/both/
+redirect PNNL_base.dss
+set maxiterations=80
+set controlmode=off
+solve
+cd /home/tom/src/Powergrid-Models/platform/test/dss/
+export summary  PNNL_s.csv
+export voltages PNNL_v.csv
+export currents PNNL_i.csv
+export taps     PNNL_t.csv
+

--- a/platform/check_pnnl.sh
+++ b/platform/check_pnnl.sh
@@ -1,0 +1,4 @@
+cd /home/tom/src/Powergrid-Models/platform/both/
+gridlabd -D WANT_VI_DUMP=1 PNNL_run.glm >../test/glm/PNNL.log
+mv PNNL*.csv ../test/glm
+

--- a/platform/der/.gitignore
+++ b/platform/der/.gitignore
@@ -1,0 +1,6 @@
+*.json
+*base.dss
+*base.glm
+*uuid.dss
+*busxy.dss
+*.csv

--- a/platform/der/check.dss
+++ b/platform/der/check.dss
@@ -1,0 +1,10 @@
+clear
+redirect ieee13_der_base.dss
+set maxiterations=80
+set controlmode=off
+solve
+export summary  ieee13_s.csv
+export voltages ieee13_v.csv
+export currents ieee13_i.csv
+export taps     ieee13_t.csv
+

--- a/platform/der/clean.sh
+++ b/platform/der/clean.sh
@@ -1,0 +1,2 @@
+rm *.csv
+rm gridlabd.xml

--- a/platform/der/ieee13_der_run.glm
+++ b/platform/der/ieee13_der_run.glm
@@ -1,0 +1,30 @@
+clock {
+  timezone EST+5EDT;
+  starttime '2000-01-01 0:00:00';
+  stoptime '2000-01-01 0:00:00';
+};
+#set relax_naming_rules=1
+#set profiler=1
+module powerflow {
+  solver_method NR;
+  line_capacitance TRUE;
+};
+module generators;
+module residential;
+module tape;
+module reliability {
+  report_event_log false;
+};
+#include "../support/appliance_schedules.glm"
+#define VSOURCE=66395.3
+#include "ieee13_der_base.glm";
+#ifdef WANT_VI_DUMP
+object voltdump {
+  filename ieee13_der_volt.csv;
+  mode POLAR;
+};
+object currdump {
+  filename ieee13_der_curr.csv;
+  mode POLAR;
+};
+#endif

--- a/platform/envars.sh
+++ b/platform/envars.sh
@@ -1,7 +1,7 @@
 #declare -r DB_URL="http://blazegraph:8080/bigdata/namespace/kb/sparql"
 declare -r DB_URL="http://localhost:8889/bigdata/namespace/kb/sparql"
 declare -r SRC_PATH="/home/tom/src/Powergrid-Models/platform/"
-declare -r CIMHUB_PATH="../../CIMHub/target/libs/*:../../CIMHub/target/cimhub-0.0.1-SNAPSHOT.jar"
+declare -r CIMHUB_PATH="../../CIMHub/target/libs/*:../../CIMHub/cimhub/target/cimhub-0.0.2-SNAPSHOT.jar"
 declare -r CIMHUB_PROG="gov.pnnl.gridappsd.cimhub.CIMImporter"
 declare -r CIMHUB_UTILS="../../CIMHub/utils"
 

--- a/platform/pnnl_measurements.sh
+++ b/platform/pnnl_measurements.sh
@@ -1,0 +1,11 @@
+source envars.sh
+python3 $CIMHUB_UTILS/ListMeasureables.py cimhubconfig.json pnnl _0EAA27FD-4D5F-4F29-A928-939CF7D0EBA0 Meas
+
+python3 $CIMHUB_UTILS/InsertMeasurements.py cimhubconfig.json ./Meas/pnnl_lines_pq.txt  ./Meas/pnnl_msid.json
+python3 $CIMHUB_UTILS/InsertMeasurements.py cimhubconfig.json ./Meas/pnnl_loads.txt     ./Meas/pnnl_msid.json
+python3 $CIMHUB_UTILS/InsertMeasurements.py cimhubconfig.json ./Meas/pnnl_node_v.txt    ./Meas/pnnl_msid.json
+python3 $CIMHUB_UTILS/InsertMeasurements.py cimhubconfig.json ./Meas/pnnl_special.txt   ./Meas/pnnl_msid.json
+python3 $CIMHUB_UTILS/InsertMeasurements.py cimhubconfig.json ./Meas/pnnl_switch_i.txt  ./Meas/pnnl_msid.json
+python3 $CIMHUB_UTILS/InsertMeasurements.py cimhubconfig.json ./Meas/pnnl_xfmr_pq.txt   ./Meas/pnnl_msid.json
+
+

--- a/platform/test_all_der.sh
+++ b/platform/test_all_der.sh
@@ -1,0 +1,15 @@
+source envars.sh
+
+#java -cp $CIMHUB_PATH $CIMHUB_PROG -u=$DB_URL -o=idx test
+
+java -cp $CIMHUB_PATH $CIMHUB_PROG -u=$DB_URL \
+   -s=_49AD8E07-3BF9-A4E2-CB8F-C3722F837B62 -o=both -l=1.0 -i=1 der/ieee13_der
+
+cd der
+
+gridlabd -D WANT_VI_DUMP=1 ieee13_der_run.glm >ieee13_der.log
+opendsscmd check.dss
+
+tail *.log
+tail *_s.csv
+

--- a/platform/test_pnnl.sh
+++ b/platform/test_pnnl.sh
@@ -1,0 +1,12 @@
+source envars.sh
+
+curl -D- -X POST $DB_URL --data-urlencode "update=drop all"
+curl -D- -H "Content-Type: application/xml" --upload-file /home/tom/src/Powergrid-Models/platform/cimxml/PNNL.xml -X POST $DB_URL
+java -cp $CIMHUB_PATH $CIMHUB_PROG -o=both -l=1.0 -i=1 /home/tom/src/Powergrid-Models/platform/both/PNNL
+
+opendsscmd check_pnnl.dss
+
+python3 MakeGlmTestScript.py $SRC_PATH
+./check_pnnl.sh
+#python3 Compare_Cases.py
+


### PR DESCRIPTION
March 30 change restores the missing secondary bus coordinates in IEEE 8500-node system (note: EPRI keeps 3 versions of this data in SourceForge and one got out of synch). Circuit should now display correctly.

The March 17 and 18 changes don't affect the platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/powergrid-models/94)
<!-- Reviewable:end -->
